### PR TITLE
remove ro.vendor.build.svn sysprop

### DIFF
--- a/device-husky.mk
+++ b/device-husky.mk
@@ -436,3 +436,5 @@ PRODUCT_VENDOR_PROPERTIES += \
 
 PRODUCT_PACKAGES += \
 	NfcOverlayHusky \
+
+PRODUCT_VENDOR_PROPERTIES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_VENDOR_PROPERTIES))

--- a/device-shiba.mk
+++ b/device-shiba.mk
@@ -402,3 +402,5 @@ PRODUCT_VENDOR_PROPERTIES += \
 
 PRODUCT_PACKAGES += \
     NfcOverlayShiba
+
+PRODUCT_VENDOR_PROPERTIES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_VENDOR_PROPERTIES))


### PR DESCRIPTION
Value of ro.vendor.build.svn in stock OS image used by adevtool might not match the value specified here, e.g. when base AOSP tag doesn't match the tag that was used for stock OS build.

adevtool automatically adds missing properties, i.e. removal of ro.vendor.build.svn from here means that ro.vendor.build.svn sysprop value from stock OS image will be used instead.